### PR TITLE
rpm: disable debugsource subpackage building.

### DIFF
--- a/rpm/sid.spec
+++ b/rpm/sid.spec
@@ -35,7 +35,7 @@ mv %{name}-mvp-%{version}/* .
 
 %build
 ./autogen.sh
-./configure --disable-mod-multipath_component CC=gcc CFLAGS="-g0 -O0 -Wall"
+./configure --disable-mod-multipath_component CC=gcc
 make
 
 %install


### PR DESCRIPTION
The Copr build is failed because of missing file for debugsource package.
I disabled the build of debugsource.